### PR TITLE
Enable Wi-Fi etc. to work in LuneOS again

### DIFF
--- a/scripts/halium
+++ b/scripts/halium
@@ -441,7 +441,7 @@ mountroot() {
 		for x in $(cat /proc/cmdline); do
 			case ${x} in
 			systempart=*)
-				syspart=${x#*=}
+				_syspart=${x#*=}
 				;;
 			esac
 		done

--- a/scripts/halium
+++ b/scripts/halium
@@ -487,7 +487,7 @@ mountroot() {
 	else
 		# Neither of those exist, remount read-only
 		tell_kmsg "mounting $_syspart $imagefile (user mode)"
-		mount -o remount,ro /halium-system
+		#mount -o remount,ro /halium-system
 		mountroot_status="$?"
 	fi
 


### PR DESCRIPTION
Not really expecting you to merge this. I just want to show you what the problems are.

If /halium-system is ro, the userdata mountpoint cannot be created.

I don't think we use the _syspart variable anyway, but it was a typo I'm sure.
Why it was renamed from syspart remains a mystery.